### PR TITLE
Remove incorrect SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,0 @@
-# Security Policy
-
-Report privately via https://issues.jenkins.io/ (INFRA → plugins).


### PR DESCRIPTION
The change proposed removes the incorrect security instructions and restores the default from the organization template: https://github.com/jenkinsci/.github/blob/master/SECURITY.md
(GitHub will display this over the local file)